### PR TITLE
Add pagination to verses-map endpoint

### DIFF
--- a/app/Http/Controllers/CalculatorController.php
+++ b/app/Http/Controllers/CalculatorController.php
@@ -38,9 +38,9 @@ class CalculatorController extends Controller
 
     public function mapVerses()
     {
-        $this->fullSura->verses = $this->processVerses($this->fullSura->suraFile);
+        $verses = $this->processVerses($this->fullSura->suraFile);
 
-        return $this->jsonResponse($this->fullSura);
+        return $this->jsonResponse($this->paginate($verses));
     }
 
     private function processVerses($verses)

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -1,14 +1,5 @@
 <?php
-/**
- * MyClass Class Doc Comment
- *
- * @category Class
- * @package  MyPackage
- * @author    A N Other
- * @license  http://www.gnu.org/copyleft/gpl.html GNU General Public License
- * @link     http://www.hashbangcode.com/
- *
- */
+
 namespace App\Http\Controllers;
 
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -28,5 +19,23 @@ class Controller extends BaseController
             ['Content-Type' => 'application/json;charset=UTF-8', 'Charset' => 'utf-8'],
             JSON_UNESCAPED_UNICODE
         );
+    }
+
+    /**
+     *
+     * @param array|Collection      $items
+     * @param int   $perPage
+     * @param int  $page
+     * @param array $options
+     *
+     * @return LengthAwarePaginator
+     */
+    public function paginate($items, $perPage = 15, $page = null, $options = [])
+    {
+        $page = $page ?: (\Illuminate\Pagination\Paginator::resolveCurrentPage() ?: 1);
+        $items = $items instanceof \Illuminate\Support\Collection ? $items : \Illuminate\Support\Collection::make($items);
+
+        return new \Illuminate\Pagination\LengthAwarePaginator(array_values($items->forPage($page, $perPage)->toArray()), $items->count(), $perPage, $page, $options);
+
     }
 }

--- a/app/Verse.php
+++ b/app/Verse.php
@@ -4,6 +4,7 @@ namespace App;
 
 use App\FullSura;
 use App\Word;
+use Illuminate\Support\Collection;
 
 class Verse extends FullSura
 {
@@ -28,7 +29,7 @@ class Verse extends FullSura
 
     public function indexVerseWords()
     {
-        $verseWords = [];
+        $verseWords = new Collection();
 
         foreach ($this->verseArray as $index => $word) {
             $wordObject = new Word($word, $index + 1);
@@ -36,7 +37,7 @@ class Verse extends FullSura
             $wordObject->Word = $wordObject->string;
             $wordObject->Letters = $wordObject->letters;
             
-            $verseWords[$word] = $wordObject;
+            $verseWords->push($wordObject);
         }
 
         return $verseWords;


### PR DESCRIPTION
Created a `collection` instead of an `array`, and added `pagination` method to base controller

`verses-map` endpoint is now paginated. This might not be the right idea, but for now it lessens the load for big texts. 

Simply add the page number to the query string to go back and forth, for example `verses-map?page=3`
Some helpful meta data will be returned at the bottom of the json response 